### PR TITLE
Update PlaceholderAPI repo and version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         </repository>
         <repository>
             <id>placeholderapi</id>
-            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
     </repositories>
 
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.8.4</version>
+            <version>2.11.6</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary
- use HTTPS placeholderapi repository
- bump `me.clip:placeholderapi` to `2.11.6`

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_6867119cea2c832ca777fcd16029bc03