### PR TITLE
Fix case handling for placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Geolocation provides the following placeholders:
 
 Replace `<identifier>` in `%geolocation_<identifier>%` to use. When data has not yet been fetched, the placeholders will temporarily display `Retrieving...`.
 
-- __county__ Returns the player's country. _Ex: United States_
+- __country__ Returns the player's country. _Ex: United States_
 - __countryCode__ Returns the player's country code. _Ex: US_
 - __regionName__ Returns the player's region name. _Ex: Virginia_
 - __region__ Returns the player's region code. _Ex: VA_

--- a/src/main/java/me/itsnathang/placeholders/LocationInfo.java
+++ b/src/main/java/me/itsnathang/placeholders/LocationInfo.java
@@ -43,7 +43,27 @@ public class LocationInfo {
 
     public String getData(String key) {
         if (data == null) return "API Down";
-        return data.containsKey(key) ? data.get(key).toString() : "invalid identifier";
+
+        // ip-api keys are case sensitive while PlaceholderAPI provides
+        // identifiers in lower case, so map the requested identifier to the
+        // correct JSON key
+        String actualKey = mapKey(key);
+
+        return data.containsKey(actualKey)
+                ? data.get(actualKey).toString()
+                : "Invalid Identifier";
+    }
+
+    private String mapKey(String key) {
+        switch (key.toLowerCase()) {
+            case "countrycode":
+                return "countryCode";
+            case "regionname":
+                return "regionName";
+            default:
+                // most keys from ip-api are already lower case
+                return key.toLowerCase();
+        }
     }
 
     public boolean isValid() {


### PR DESCRIPTION
## Summary
- handle PlaceholderAPI identifiers in lower case by mapping to the proper JSON keys
- correct placeholder name in README

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686715059a14832c8565f18d1401ea05